### PR TITLE
[codex] deepen portfolio pages narrative

### DIFF
--- a/docs/assets/stylesheets/portfolio.css
+++ b/docs/assets/stylesheets/portfolio.css
@@ -196,7 +196,8 @@ body:has(.portfolio-page) .md-typeset h3 {
 .md-typeset .portfolio-stat-strip,
 .md-typeset .portfolio-card-grid,
 .md-typeset .portfolio-status-grid,
-.md-typeset .portfolio-project-grid {
+.md-typeset .portfolio-project-grid,
+.md-typeset .portfolio-system-map {
   display: grid;
   gap: 0.9rem;
   margin: 1.15rem 0;
@@ -218,9 +219,15 @@ body:has(.portfolio-page) .md-typeset h3 {
   grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
 }
 
+.md-typeset .portfolio-system-map {
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  counter-reset: portfolio-system;
+}
+
 .md-typeset .portfolio-card,
 .md-typeset .portfolio-stat,
 .md-typeset .portfolio-status-card,
+.md-typeset .portfolio-system-node,
 .md-typeset .portfolio-step,
 .md-typeset .portfolio-faq-item {
   border: 1px solid var(--portfolio-line);
@@ -232,6 +239,7 @@ body:has(.portfolio-page) .md-typeset h3 {
 [data-md-color-scheme="slate"] .md-typeset .portfolio-card,
 [data-md-color-scheme="slate"] .md-typeset .portfolio-stat,
 [data-md-color-scheme="slate"] .md-typeset .portfolio-status-card,
+[data-md-color-scheme="slate"] .md-typeset .portfolio-system-node,
 [data-md-color-scheme="slate"] .md-typeset .portfolio-step,
 [data-md-color-scheme="slate"] .md-typeset .portfolio-faq-item {
   box-shadow: none;
@@ -239,6 +247,7 @@ body:has(.portfolio-page) .md-typeset h3 {
 
 .md-typeset .portfolio-card,
 .md-typeset .portfolio-status-card,
+.md-typeset .portfolio-system-node,
 .md-typeset .portfolio-faq-item {
   padding: 1rem;
 }
@@ -249,6 +258,7 @@ body:has(.portfolio-page) .md-typeset h3 {
 
 .md-typeset .portfolio-stat small,
 .md-typeset .portfolio-card small,
+.md-typeset .portfolio-system-node small,
 .md-typeset .portfolio-status-card small {
   display: block;
   color: var(--portfolio-muted);
@@ -268,18 +278,33 @@ body:has(.portfolio-page) .md-typeset h3 {
 
 .md-typeset .portfolio-stat span,
 .md-typeset .portfolio-card p,
+.md-typeset .portfolio-system-node p,
 .md-typeset .portfolio-status-card p,
 .md-typeset .portfolio-step p {
   color: var(--portfolio-muted);
 }
 
 .md-typeset .portfolio-card h3,
+.md-typeset .portfolio-system-node h3,
 .md-typeset .portfolio-status-card h3,
 .md-typeset .portfolio-step h3 {
   margin: 0.15rem 0 0.35rem;
   color: var(--portfolio-ink);
   font-size: 1.05rem;
   letter-spacing: 0;
+}
+
+.md-typeset .portfolio-system-node {
+  position: relative;
+  overflow: hidden;
+}
+
+.md-typeset .portfolio-system-node::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: var(--portfolio-teal);
 }
 
 .md-typeset .portfolio-status-card {

--- a/docs/projects/overview.md
+++ b/docs/projects/overview.md
@@ -3,102 +3,213 @@
 <div class="portfolio-page" markdown="1">
 
 <div class="portfolio-hero" markdown="1">
-<span class="portfolio-eyebrow">Project evidence</span>
+<span class="portfolio-eyebrow">Monorepo production evidence</span>
 
-# Three ML projects, one production mindset
+# One ML monorepo, three services, two cloud paths
 
-Each project starts with a machine learning problem, then goes one step further:
-API design, testing, deployment artifacts, monitoring and documentation.
+This is not a collection of isolated notebooks. The portfolio is a monorepo
+that turns three different ML problems into reviewable production systems:
+model code, APIs or batch paths, Docker images, Kubernetes manifests,
+multi-cloud deployment evidence, monitoring, CI/CD and documentation.
 
 <div class="portfolio-actions" markdown="1">
 [Watch the video demo](https://youtu.be/7dFFqq2ROPw){ .portfolio-button .portfolio-button--primary }
 [Review technical evidence](../technical-evidence.md){ .portfolio-button }
+[View deployment evidence](../DEPLOYMENT_EVIDENCE.md){ .portfolio-button }
+</div>
+</div>
+
+<div class="portfolio-stat-strip" markdown="1">
+<div class="portfolio-stat">
+<small>Service modules</small>
+<strong>3 ML systems</strong>
+<span>Churn, financial NLP and taxi demand forecasting.</span>
+</div>
+<div class="portfolio-stat">
+<small>Validation surface</small>
+<strong>395+ tests</strong>
+<span>Unit, integration, API, infra and smoke coverage.</span>
+</div>
+<div class="portfolio-stat">
+<small>Deployment evidence</small>
+<strong>GKE + EKS</strong>
+<span>Real multi-cloud runtime evidence, now cost-controlled.</span>
+</div>
+<div class="portfolio-stat">
+<small>Architecture record</small>
+<strong>18 ADRs</strong>
+<span>Decisions covering reliability, cost, security and scope.</span>
 </div>
 </div>
 
 <div class="portfolio-media" markdown="1">
-<img src="../media/gifs/portfolio-demo.gif" alt="Portfolio Demo">
+<img src="../media/gifs/portfolio-demo.gif" alt="Portfolio demo showing the MLOps portfolio flow">
 </div>
 
-## The Three Projects
+## How To Read The Portfolio
+
+<div class="portfolio-split" markdown="1">
+<div markdown="1">
+
+The strongest signal is the system shape. Each project proves a different ML
+problem, but the portfolio is meant to be reviewed as one end-to-end operating
+environment: code, validation, serving, infrastructure, observability and
+handoff documentation.
+
+That matters because production ML is rarely just the model. The work is in
+making the model testable, deployable, explainable and safe enough for another
+person to operate.
+
+</div>
+<div class="portfolio-callout" markdown="1">
+<strong>Recruiter takeaway</strong>
+
+I can build ML work that is easier to review than a notebook-only project:
+there is evidence of tests, deployment thinking, cloud operations and written
+trade-offs.
+</div>
+</div>
+
+## System View
+
+<div class="portfolio-system-map" markdown="1">
+<div class="portfolio-system-node" markdown="1">
+<small>1. Data and features</small>
+<h3>Leakage-aware inputs</h3>
+<p>Temporal validation, cost-aware thresholds, text preprocessing and PySpark
+ETL appear where the project needs them.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>2. Model development</small>
+<h3>Metrics with context</h3>
+<p>AUC, accuracy, R2, explainability and dataset limitations are documented
+instead of treated as one-line leaderboard numbers.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>3. Serving and batch paths</small>
+<h3>APIs beyond notebooks</h3>
+<p>FastAPI, prediction contracts, smoke checks and batch-oriented paths make the
+models callable and reviewable.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>4. Runtime packaging</small>
+<h3>Docker and Kubernetes</h3>
+<p>Each service has runtime artifacts that can be built, scanned, deployed and
+debugged outside a local notebook.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>5. Cloud evidence</small>
+<h3>GCP and AWS</h3>
+<p>The portfolio includes GKE and EKS evidence, Artifact Registry/ECR paths,
+storage buckets and deployment screenshots.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>6. Operations and handoff</small>
+<h3>Monitoring, ADRs and runbooks</h3>
+<p>Prometheus/Grafana, MLflow evidence, troubleshooting notes and architecture
+decisions make the system easier to operate.</p>
+</div>
+</div>
+
+## Service Modules
 
 <div class="portfolio-project-grid" markdown="1">
 <div class="portfolio-card" markdown="1">
-<small>Banking churn</small>
+<small>Banking churn service</small>
 <h3><a href="../bankchurn/">BankChurn Predictor</a></h3>
-<p>Predict which banking customers may churn, then connect the model to
-cost-aware threshold tuning and SHAP explanations.</p>
+<p>Predicts customer churn and connects model performance to cost-aware
+threshold tuning, SHAP explanations and serving reliability improvements.</p>
 <p><strong>Main signal:</strong> AUC 0.87, 90% test coverage and documented
-serving reliability improvements.</p>
+FastAPI/Kubernetes hardening.</p>
 </div>
 
 <div class="portfolio-card" markdown="1">
-<small>Financial NLP</small>
+<small>Financial NLP service</small>
 <h3><a href="../nlpinsight/">NLPInsight Analyzer</a></h3>
-<p>Classify sentiment in financial text with a lightweight production path and
-an optional transformer path.</p>
-<p><strong>Main signal:</strong> 80.6% accuracy, 98% coverage and a more honest
-dataset choice over an easier benchmark.</p>
+<p>Classifies sentiment in financial text with a lightweight production path,
+an optional transformer path and explicit dataset trade-off documentation.</p>
+<p><strong>Main signal:</strong> 80.6% accuracy, 98% coverage and an honest
+modeling path over an easier benchmark.</p>
 </div>
 
 <div class="portfolio-card" markdown="1">
-<small>Taxi demand</small>
+<small>Demand forecasting pipeline</small>
 <h3><a href="../chicagotaxi/">ChicagoTaxi Pipeline</a></h3>
-<p>Forecast taxi demand from trip data using PySpark ETL, temporal validation
+<p>Forecasts taxi demand from trip data using PySpark ETL, temporal validation
 and leakage-aware feature engineering.</p>
 <p><strong>Main signal:</strong> R2 0.96, 6.3M rows processed and leakage removed
 from the feature set.</p>
 </div>
 </div>
 
-## What They Have In Common
+## Monorepo Depth
 
 <div class="portfolio-card-grid" markdown="1">
 <div class="portfolio-card" markdown="1">
-<small>Code quality</small>
-<h3>Python workflows with tests</h3>
-<p>Each project has reviewable code, fixtures and automated tests rather than
-notebook-only output.</p>
+<small>Shared production pattern</small>
+<h3>Repeated operating shape</h3>
+<p>The services are different ML problems, but they converge on the same
+production questions: testing, packaging, runtime health and deployability.</p>
 </div>
 
 <div class="portfolio-card" markdown="1">
-<small>Serving and pipelines</small>
-<h3>APIs or batch paths</h3>
-<p>The projects expose systems that can be exercised, monitored and reviewed.</p>
+<small>Multi-cloud proof</small>
+<h3>GKE and EKS were exercised</h3>
+<p>The cloud environments are not running now for cost reasons, but the repo
+keeps screenshots, CLI evidence, manifests and comparison notes.</p>
 </div>
 
 <div class="portfolio-card" markdown="1">
-<small>Deployment artifacts</small>
-<h3>Docker and Kubernetes</h3>
-<p>Runtime artifacts are part of the portfolio, even when cloud infrastructure is
-not currently running.</p>
+<small>CI/CD discipline</small>
+<h3>Checks before claims</h3>
+<p>The portfolio includes automated tests, documentation validation, security
+scanning, Docker validation and quality gates.</p>
 </div>
 
 <div class="portfolio-card" markdown="1">
-<small>Decision quality</small>
-<h3>Trade-offs are documented</h3>
-<p>Latency, cost, explainability, leakage and maintenance decisions are written
-down for reviewers.</p>
+<small>Template extraction</small>
+<h3>Lessons became reusable</h3>
+<p>The production patterns were extracted into the ML-MLOps Production Template,
+which is the strongest proof of product thinking in the portfolio.</p>
 </div>
 </div>
 
-## Why These Projects Matter For Junior Roles
+## What This Proves
 
-<div class="portfolio-callout" markdown="1">
-I am not claiming years of professional ML platform ownership. These projects
-show that I can learn the tools, connect them into working systems, explain my
-decisions and notice operational risks that matter in real teams.
+<div class="portfolio-card-grid" markdown="1">
+<div class="portfolio-card" markdown="1">
+<small>For recruiters</small>
+<h3>More than training models</h3>
+<p>The portfolio shows a candidate who can explain systems, not just model
+scores: cloud, testing, reliability, documentation and cost trade-offs.</p>
 </div>
 
-For a recruiter, the simple takeaway is:
+<div class="portfolio-card" markdown="1">
+<small>For technical reviewers</small>
+<h3>Evidence is inspectable</h3>
+<p>There are source files, tests, screenshots, ADRs, API references, deployment
+notes and operational docs to review independently.</p>
+</div>
 
-> I can help build, test, document and operate ML services while continuing to
-> grow under experienced technical guidance.
+<div class="portfolio-card" markdown="1">
+<small>For team fit</small>
+<h3>Junior scope, production habits</h3>
+<p>I am not claiming years of ML platform ownership. I am showing that I can
+learn quickly, build carefully and work inside real engineering constraints.</p>
+</div>
+</div>
 
-For a technical reviewer, the deeper evidence is here:
+## Deeper Evidence
 
 - [Technical Evidence](../technical-evidence.md)
 - [Architecture decisions](../architecture/decisions.md)
+- [Multi-cloud deployment evidence](../DEPLOYMENT_EVIDENCE.md)
 - [Portfolio status](../PORTFOLIO_STATUS.md)
+- [Production template](../template.md)
 
 </div>

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,57 +1,222 @@
-# ML-MLOps Production Template
+# Production Template
 
-## The Project I Am Most Proud Of
+<div class="portfolio-page portfolio-template" markdown="1">
+
+<div class="portfolio-hero" markdown="1">
+<span class="portfolio-eyebrow">Production template and agentic operating model</span>
+
+# A reusable ML service template with governed AI-assisted engineering
 
 The [ML-MLOps Production Template](https://github.com/DuqueOM/ML-MLOps-Production-Template)
-is a reusable starter framework for machine learning services that need more
-than a notebook.
+is the strongest artifact in this portfolio. It packages the production lessons
+from the monorepo into a starter system for ML services: FastAPI serving,
+training/serving parity, CI/CD, Docker, Kubernetes, Terraform examples,
+observability hooks, runbooks and an explicit agentic governance model.
 
-It came from building this portfolio and asking: if I had to start the next ML
-service tomorrow, what mistakes would I want to avoid from day one?
+<div class="portfolio-actions" markdown="1">
+[Open the template repo](https://github.com/DuqueOM/ML-MLOps-Production-Template){ .portfolio-button .portfolio-button--primary }
+[Read the quick start](https://github.com/DuqueOM/ML-MLOps-Production-Template/blob/main/QUICK_START.md){ .portfolio-button }
+[Review technical evidence](technical-evidence.md){ .portfolio-button }
+</div>
+</div>
 
-## Why It Matters
+<div class="portfolio-stat-strip" markdown="1">
+<div class="portfolio-stat">
+<small>Serving baseline</small>
+<strong>FastAPI scaffold</strong>
+<span>Predict, batch predict, health, readiness, metrics and model operations.</span>
+</div>
+<div class="portfolio-stat">
+<small>Cloud posture</small>
+<strong>GKE + EKS ready</strong>
+<span>Kubernetes overlays and Terraform examples for both paths.</span>
+</div>
+<div class="portfolio-stat">
+<small>Agentic governance</small>
+<strong>AUTO / CONSULT / STOP</strong>
+<span>Rules for when agents can act, ask or halt for safety.</span>
+</div>
+<div class="portfolio-stat">
+<small>Adoption status</small>
+<strong>Production-ready by design</strong>
+<span>Template defaults are documented, tested and reviewable.</span>
+</div>
+</div>
 
-The template is not only a collection of files. It is a packaged set of lessons:
+## Why This Is More Than A Template
 
-- how to structure a FastAPI model service;
-- how to keep model artifacts out of Docker images;
-- how to track experiments and model versions;
-- how to add CI/CD and validation early;
-- how to prepare deployment manifests for Kubernetes;
-- how to document decisions so a future teammate can understand them;
-- how to keep AI-assisted development inside safe, reviewable rules.
+<div class="portfolio-split" markdown="1">
+<div markdown="1">
 
-For non-technical readers: it is like a checklist and starter kit for building
-ML services with fewer avoidable mistakes.
+The template is not only a folder structure. It is an operating contract for
+starting ML services with fewer avoidable mistakes. It defines what a generated
+service should contain, how it should be validated, which deployment paths it
+can follow and how AI agents are allowed to participate in the work.
 
-For technical reviewers: it includes service scaffolding, Kubernetes/Terraform
-patterns, MLflow hooks, drift and retraining workflows, CI validation, security
-checks, and an agent behavior protocol.
+The important point is the second-order artifact: I did not only build three
+portfolio services. I extracted the reusable production system behind them.
+
+</div>
+<div class="portfolio-callout" markdown="1">
+<strong>Staff reviewer signal</strong>
+
+The most distinctive part is the agentic operating model: canonical rules,
+skills, workflows and risk escalation are written as code-adjacent governance,
+not left as informal prompting.
+</div>
+</div>
+
+## Production Scaffold Contract
+
+<div class="portfolio-system-map" markdown="1">
+<div class="portfolio-system-node" markdown="1">
+<small>1. Service API</small>
+<h3>FastAPI by default</h3>
+<p>The scaffold includes prediction endpoints, batch prediction, readiness,
+health, metrics, error envelopes, auth hooks and model metadata.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>2. ML lifecycle</small>
+<h3>Training to serving parity</h3>
+<p>Feature engineering, schema validation, model loading and inference contracts
+are treated as one path instead of separate notebook and API worlds.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>3. Quality gates</small>
+<h3>CI before adoption</h3>
+<p>YAML checks, workflow checks, scaffold tests, smoke paths, pre-commit hooks
+and targeted validations protect the generated service.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>4. Runtime</small>
+<h3>Docker and Kubernetes</h3>
+<p>Containers, Kustomize overlays, readiness probes and deployment defaults are
+part of the service contract from the beginning.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>5. Observability</small>
+<h3>Metrics and operations hooks</h3>
+<p>Prometheus-compatible metrics, prediction logging, tracing options, drift
+checks and retraining workflows are built into the template story.</p>
+</div>
+
+<div class="portfolio-system-node" markdown="1">
+<small>6. Cloud path</small>
+<h3>GCP and AWS patterns</h3>
+<p>The template documents GKE/EKS deployment expectations, identity patterns,
+artifact registries and operational runbooks without pretending local tests are
+cloud proof.</p>
+</div>
+</div>
+
+## Agentic Operating Model
+
+<div class="portfolio-card-grid" markdown="1">
+<div class="portfolio-card" markdown="1">
+<small>Canonical rules</small>
+<h3>One source of truth</h3>
+<p><code>AGENTS.md</code>, agent context and the manifest define the behavior contract.
+Adapter files point to canonical rules instead of drifting into parallel policy.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Risk matrix</small>
+<h3>AUTO / CONSULT / STOP</h3>
+<p>Low-risk work can be automated, ambiguous production work requires user
+consultation, and destructive or safety-sensitive actions must stop.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Workflow skills</small>
+<h3>Repeatable MLOps actions</h3>
+<p>New service creation, drift checks, retraining, rollback, cost review,
+release, incident and security workflows are encoded as reusable agent skills.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Reviewability</small>
+<h3>Agents leave evidence</h3>
+<p>The model is designed around validation logs, changelogs, ADRs, runbooks and
+explicit test commands so agent-assisted work remains auditable.</p>
+</div>
+</div>
+
+## What A Reviewer Should Inspect
+
+<div class="portfolio-card-grid" markdown="1">
+<div class="portfolio-card" markdown="1">
+<small>First scaffold</small>
+<h3>Can it generate a usable service?</h3>
+<p>A reviewer should be able to scaffold a service, run the local checks and
+see a coherent FastAPI project with tests and deployment artifacts.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Serving contract</small>
+<h3>Does inference match training?</h3>
+<p>The service should preserve feature parity, validate inputs and expose
+readiness based on model loading rather than a superficial health endpoint.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Governance contract</small>
+<h3>Can agents act safely?</h3>
+<p>The strongest enterprise signal is whether agent workflows are bounded by
+rules, manifests, validations and explicit escalation points.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Cloud realism</small>
+<h3>Are claims scoped honestly?</h3>
+<p>The template distinguishes local validation from real GKE/EKS validation,
+which keeps the documentation useful without overstating production proof.</p>
+</div>
+</div>
 
 ## What It Shows About Me
 
 | Signal | What it means |
 |--------|---------------|
-| Product thinking | I turned a personal portfolio into a reusable tool others could start from. |
-| Operational mindset | The template focuses on reliability, deployment, monitoring, and handoffs. |
-| Documentation discipline | Decisions, runbooks, and rules are written down, not hidden in memory. |
-| Safety awareness | Secrets, image scanning, model promotion, and deployment guardrails are treated as first-class concerns. |
-| Learning velocity | I used the portfolio lessons to create a stronger second system. |
-
-## Key Capabilities
-
-| Area | Examples |
-|------|----------|
-| Service foundation | FastAPI, model loading, health/readiness checks, tests. |
-| ML workflow | MLflow experiment tracking, model registry patterns, model versioning. |
-| Deployment path | Docker, Kubernetes, Kustomize, Terraform examples for GCP and AWS. |
-| CI/CD | GitHub Actions validation, smoke checks, security scans. |
-| Monitoring | Prometheus/Grafana patterns, drift checks, retraining hooks. |
-| Governance | AUTO / CONSULT / STOP workflow rules for safe agent-assisted engineering. |
+| Product thinking | I turned portfolio lessons into a reusable starter system. |
+| MLOps discipline | The template treats serving, testing, packaging and deployment as one system. |
+| Governance mindset | AI-assisted engineering is bounded by explicit rules, not only prompts. |
+| Operational honesty | Cloud validation, cost control and limitations are documented instead of hidden. |
+| Documentation taste | The repo is designed so another engineer can adopt, review and improve it. |
 
 ## Where To Go Next
 
-- [Template repository](https://github.com/DuqueOM/ML-MLOps-Production-Template)
-- [Quick Start](https://github.com/DuqueOM/ML-MLOps-Production-Template/blob/main/QUICK_START.md)
-- [Architecture decisions](https://github.com/DuqueOM/ML-MLOps-Production-Template/tree/main/docs/decisions)
-- [Technical evidence from this portfolio](technical-evidence.md)
+<div class="portfolio-card-grid" markdown="1">
+<div class="portfolio-card" markdown="1">
+<small>Repository</small>
+<h3><a href="https://github.com/DuqueOM/ML-MLOps-Production-Template">Template source</a></h3>
+<p>Start here for the actual scaffold, docs, workflows, rules and release
+history.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Adoption path</small>
+<h3><a href="https://github.com/DuqueOM/ML-MLOps-Production-Template/blob/main/QUICK_START.md">Quick Start</a></h3>
+<p>Best entry point for generating and validating a new service from the
+template.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Decision trail</small>
+<h3><a href="https://github.com/DuqueOM/ML-MLOps-Production-Template/tree/main/docs/decisions">Architecture decisions</a></h3>
+<p>Review the trade-offs behind the template instead of only reading the final
+structure.</p>
+</div>
+
+<div class="portfolio-card" markdown="1">
+<small>Portfolio context</small>
+<h3><a href="technical-evidence.md">Technical evidence</a></h3>
+<p>See how the template relates to the broader monorepo, cloud evidence and
+production ML portfolio.</p>
+</div>
+</div>
+
+</div>


### PR DESCRIPTION
## What changed

- Reworked `Projects Overview` so it reads as one end-to-end MLOps monorepo rather than three isolated ML demos.
- Reworked `Production Template` into a flagship page centered on the production scaffold and governed agentic operating model.
- Added a reusable `portfolio-system-map` visual component for system-layer storytelling.

## Why

The existing Pages UX was much stronger after the prior refresh, but these two pages were underselling the strongest evidence:

- the portfolio is a multi-service, multi-cloud monorepo with real production artifacts;
- the template is not a notebook starter, it is a production ML template plus explicit agent governance.

## Validation

- `git diff --check`
- `mkdocs build --clean`
- Chrome headless screenshots for desktop Projects, desktop Template and mobile Template
